### PR TITLE
feat: create multiple virtual machines in Virtualbox

### DIFF
--- a/virtualbox/Vagrantfile
+++ b/virtualbox/Vagrantfile
@@ -3,23 +3,35 @@ API_VERSION = "2"
 require "yaml"
 
 config_file = ENV["CONFIG_FILE"] || "config/default.yaml"
-var = YAML.load_file config_file
+config = YAML.load_file config_file
+machines = config["machines"]
 
 Vagrant.configure(API_VERSION) do |config|
-  config.vm.provider :virtualbox do |virtualbox|
-    virtualbox.name = var["name"]
-    virtualbox.cpus = var["cpu"]
-    virtualbox.memory = var["memory"]
+  machines.each do |machine|
+    config.vm.define machine["name"] do |name|
+      
+      name.vm.provider :virtualbox do |virtualbox|
+        virtualbox.name = machine["name"]
+        virtualbox.cpus = machine["cpu"]
+        virtualbox.memory = machine["memory"]
+        virtualbox.linked_clone = machine["linked_clone"]
+      end
+    
+      name.vm.box = machine["box"]
+      name.vm.hostname = machine["name"]
+      name.vm.network :private_network, ip: machine["private_ip"]
+      
+      name.vm.provision "shell", path: machine["shell_script_path"]
+ 
+      name.vm.provision "ansible" do |ansible|
+        ansible.compatibility_mode = "2.0"
+        ansible.playbook = machine["ansible_playbook_path"]
+      end
+    
+    end
   end
-
-  config.vm.box = var["box"]
-  config.vm.hostname = var["name"]
-  config.vm.network :private_network, ip: var["private_ip"]
+  
   config.vm.synced_folder ".", "/vagrant", disabled: true
-
-  # http://stackoverflow.com/a/17864388/100134
-  config.vm.define var["name"] do |t|
-  end
 
   config.ssh.insert_key = false
   config.ssh.forward_agent = true
@@ -27,16 +39,11 @@ Vagrant.configure(API_VERSION) do |config|
     "~/.ssh/id_rsa", 
     "~/.vagrant.d/insecure_private_key"
   ]
-
+  
   config.vm.provision :file do |file|
     file.source = "~/.ssh/id_rsa.pub"
     file.destination = "~/.ssh/authorized_keys"
   end
 
-  config.vm.provision "shell", path: var["shell_script_path"] 
- 
-  config.vm.provision "ansible" do |ansible|
-    ansible.compatibility_mode = "2.0"
-    ansible.playbook = var["ansible_playbook_path"]
-  end
 end
+

--- a/virtualbox/config/centos.yaml
+++ b/virtualbox/config/centos.yaml
@@ -1,8 +1,0 @@
----
-name: centos
-box: centos/7
-cpu: 2
-memory: 2048
-private_ip: 192.168.56.11  # range: 192.168.56.0/21
-shell_script_path: provisioning/shell/default/configure.sh
-ansible_playbook_path: provisioning/ansible/default/playbook.yaml

--- a/virtualbox/config/centos7/one-clean-machine.yaml
+++ b/virtualbox/config/centos7/one-clean-machine.yaml
@@ -1,10 +1,10 @@
 ---
 machines:
-  - name: centos
+  - name: centos7-1
     box: centos/7
     cpu: 2
     memory: 2048
-    private_ip: 192.168.56.11  # range: 192.168.56.0/21
     linked_clone: false
+    private_ip: 192.168.56.11
     shell_script_path: provisioning/shell/default/configure.sh
     ansible_playbook_path: provisioning/ansible/default/playbook.yaml

--- a/virtualbox/config/centos7/three-clean-machines.yaml
+++ b/virtualbox/config/centos7/three-clean-machines.yaml
@@ -1,0 +1,26 @@
+---
+machines:
+  - name: centos7-1
+    box: centos/7
+    cpu: 2
+    memory: 2048
+    linked_clone: true
+    private_ip: 192.168.56.11
+    shell_script_path: provisioning/shell/default/configure.sh
+    ansible_playbook_path: provisioning/ansible/default/playbook.yaml
+  - name: centos7-2
+    box: centos/7
+    cpu: 2
+    memory: 2048
+    linked_clone: true
+    private_ip: 192.168.56.12
+    shell_script_path: provisioning/shell/default/configure.sh
+    ansible_playbook_path: provisioning/ansible/default/playbook.yaml
+  - name: centos7-3
+    box: centos/7
+    cpu: 2
+    memory: 2048
+    linked_clone: true
+    private_ip: 192.168.56.12
+    shell_script_path: provisioning/shell/default/configure.sh
+    ansible_playbook_path: provisioning/ansible/default/playbook.yaml

--- a/virtualbox/config/centos7/two-clean-machines.yaml
+++ b/virtualbox/config/centos7/two-clean-machines.yaml
@@ -1,0 +1,18 @@
+---
+machines:
+  - name: centos7-1
+    box: centos/7
+    cpu: 2
+    memory: 2048
+    linked_clone: true
+    private_ip: 192.168.56.11
+    shell_script_path: provisioning/shell/default/configure.sh
+    ansible_playbook_path: provisioning/ansible/default/playbook.yaml
+  - name: centos7-2
+    box: centos/7
+    cpu: 2
+    memory: 2048
+    linked_clone: true
+    private_ip: 192.168.56.12
+    shell_script_path: provisioning/shell/default/configure.sh
+    ansible_playbook_path: provisioning/ansible/default/playbook.yaml

--- a/virtualbox/config/ubuntu_bionic.yaml
+++ b/virtualbox/config/ubuntu_bionic.yaml
@@ -1,8 +1,0 @@
----
-name: bionic-1
-box: ubuntu/bionic64
-cpu: 2
-memory: 2048
-private_ip: 192.168.56.11  # range: 192.168.56.0/21
-shell_script_path: provisioning/shell/default/configure.sh
-ansible_playbook_path: provisioning/ansible/default/playbook.yaml

--- a/virtualbox/config/ubuntu_bionic/one-clean-machine.yaml
+++ b/virtualbox/config/ubuntu_bionic/one-clean-machine.yaml
@@ -1,10 +1,10 @@
 ---
 machines:
-  - name: centos
-    box: centos/7
+  - name: bionic-1
+    box: ubuntu/bionic64
     cpu: 2
     memory: 2048
-    private_ip: 192.168.56.11  # range: 192.168.56.0/21
     linked_clone: false
+    private_ip: 192.168.56.11
     shell_script_path: provisioning/shell/default/configure.sh
     ansible_playbook_path: provisioning/ansible/default/playbook.yaml

--- a/virtualbox/config/ubuntu_bionic/three-clean-machines.yaml
+++ b/virtualbox/config/ubuntu_bionic/three-clean-machines.yaml
@@ -1,0 +1,26 @@
+---
+machines:
+  - name: bionic-1
+    box: ubuntu/bionic64
+    cpu: 2
+    memory: 2048
+    linked_clone: true
+    private_ip: 192.168.56.11
+    shell_script_path: provisioning/shell/default/configure.sh
+    ansible_playbook_path: provisioning/ansible/default/playbook.yaml
+  - name: bionic-2
+    box: ubuntu/bionic64
+    cpu: 2
+    memory: 2048
+    linked_clone: true
+    private_ip: 192.168.56.12
+    shell_script_path: provisioning/shell/default/configure.sh
+    ansible_playbook_path: provisioning/ansible/default/playbook.yaml
+  - name: bionic-3
+    box: ubuntu/bionic64
+    cpu: 2
+    memory: 2048
+    linked_clone: true
+    private_ip: 192.168.56.12
+    shell_script_path: provisioning/shell/default/configure.sh
+    ansible_playbook_path: provisioning/ansible/default/playbook.yaml

--- a/virtualbox/config/ubuntu_bionic/two-clean-machines.yaml
+++ b/virtualbox/config/ubuntu_bionic/two-clean-machines.yaml
@@ -1,0 +1,18 @@
+---
+machines:
+  - name: bionic-1
+    box: ubuntu/bionic64
+    cpu: 2
+    memory: 2048
+    linked_clone: true
+    private_ip: 192.168.56.11
+    shell_script_path: provisioning/shell/default/configure.sh
+    ansible_playbook_path: provisioning/ansible/default/playbook.yaml
+  - name: bionic-2
+    box: ubuntu/bionic64
+    cpu: 2
+    memory: 2048
+    linked_clone: true
+    private_ip: 192.168.56.12
+    shell_script_path: provisioning/shell/default/configure.sh
+    ansible_playbook_path: provisioning/ansible/default/playbook.yaml


### PR DESCRIPTION
Modify the Vagrantfile, so that it can create multiple virtual
machines instead of one.
The number of virtual machines to create is determined by the number
of virtual machine definitions in a given config file.
Also adapt config files to the new version of the Vagrantfile.